### PR TITLE
feat: 공통 예외 처리 시스템 및 유저 엔티티 관련 기능 추가

### DIFF
--- a/src/main/java/com/example/mate/common/exception/BaseException.java
+++ b/src/main/java/com/example/mate/common/exception/BaseException.java
@@ -1,0 +1,15 @@
+package com.example.mate.common.exception;
+
+public class BaseException extends RuntimeException {
+
+    private final BaseExceptionType baseExceptionType;
+
+    public BaseException(BaseExceptionType baseExceptionType) {
+        super(baseExceptionType.message());
+        this.baseExceptionType = baseExceptionType;
+    }
+
+    public BaseExceptionType getType() {
+        return baseExceptionType;
+    }
+}

--- a/src/main/java/com/example/mate/common/exception/BaseExceptionType.java
+++ b/src/main/java/com/example/mate/common/exception/BaseExceptionType.java
@@ -1,0 +1,11 @@
+package com.example.mate.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseExceptionType {
+
+    String message();
+
+    HttpStatus status();
+}
+

--- a/src/main/java/com/example/mate/common/exception/ExceptionResponseDto.java
+++ b/src/main/java/com/example/mate/common/exception/ExceptionResponseDto.java
@@ -1,0 +1,7 @@
+package com.example.mate.common.exception;
+
+public record ExceptionResponseDto(
+        int status,
+        String message
+) {
+}

--- a/src/main/java/com/example/mate/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/mate/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,72 @@
+package com.example.mate.common.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final String MISSING_REQUEST_PARAMETER = "MISSING_REQUEST_PARAMETER";
+
+    // Custom Exception 응답
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ExceptionResponseDto> handleException(BaseException ex) {
+        log.warn(ex.getMessage(), ex);
+
+        BaseExceptionType type = ex.getType();
+        return ResponseEntity.status(type.status())
+                .body(new ExceptionResponseDto(type.status().value(), ex.getMessage()));
+    }
+
+    // Multipart Exception 응답
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ExceptionResponseDto> handleException(MultipartException ex) {
+        log.warn(ex.getMessage(), ex);
+
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(new ExceptionResponseDto(BAD_REQUEST.value(), ex.getMessage()));
+    }
+
+
+    // Request Parameter 예외 응답
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        log.warn(ex.getMessage(), ex);
+
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponseDto(BAD_REQUEST.value(), MISSING_REQUEST_PARAMETER));
+    }
+
+    // No Resource Found 예외 응답
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(
+            NoResourceFoundException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        log.warn(ex.getMessage(), ex);
+
+        return ResponseEntity.status(METHOD_NOT_ALLOWED)
+                .body(new ExceptionResponseDto(METHOD_NOT_ALLOWED.value(), METHOD_NOT_ALLOWED.name()));
+    }
+}
+

--- a/src/main/java/com/example/mate/common/response/ApiResponse.java
+++ b/src/main/java/com/example/mate/common/response/ApiResponse.java
@@ -1,0 +1,7 @@
+package com.example.mate.common.response;
+
+public record ApiResponse<T>(
+        String message,
+        T data
+) {
+}

--- a/src/main/java/com/example/mate/user/application/UserService.java
+++ b/src/main/java/com/example/mate/user/application/UserService.java
@@ -1,9 +1,23 @@
 package com.example.mate.user.application;
 
+import static com.example.mate.user.exception.UserExceptionType.NOT_EXIST_USER;
+
+import com.example.mate.user.application.dto.UserInfoResponseDto;
+import com.example.mate.user.domain.User;
+import com.example.mate.user.domain.repository.UserRepository;
+import com.example.mate.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserInfoResponseDto getUserInfoWithId(Long userId) {
+        User findUser = userRepository.findByIdAndStatusIsNotDeleted(userId)
+                .orElseThrow(() -> new UserException(NOT_EXIST_USER));
+        return UserInfoResponseDto.of(findUser);
+    }
 }

--- a/src/main/java/com/example/mate/user/application/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/mate/user/application/dto/UserInfoResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.mate.user.application.dto;
+
+import com.example.mate.user.domain.User;
+import com.example.mate.user.domain.UserStatus;
+
+public record UserInfoResponseDto(
+        Long userId,
+        UserStatus userStatus,
+        String nickname,
+        String profileUrl
+) {
+
+    public static UserInfoResponseDto of(User user) {
+        return new UserInfoResponseDto(
+                user.getId(),
+                user.getStatus(),
+                user.getNickname(),
+                user.getProfileUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/mate/user/domain/DefaultNicknamePolicy.java
+++ b/src/main/java/com/example/mate/user/domain/DefaultNicknamePolicy.java
@@ -1,0 +1,20 @@
+package com.example.mate.user.domain;
+
+import java.util.UUID;
+
+public class DefaultNicknamePolicy {
+
+    private static final int RANDOM_LENGTH = 8;
+    private static final String PREFIX = "DAO-";
+
+    public static String generatedRandomString() {
+        String randomString = generatedSubStringUUID();
+        return PREFIX + randomString;
+    }
+
+    private static String generatedSubStringUUID() {
+        return UUID.randomUUID().toString()
+                .replaceAll("-", "")
+                .substring(0, DefaultNicknamePolicy.RANDOM_LENGTH);
+    }
+}

--- a/src/main/java/com/example/mate/user/domain/DefaultNicknamePolicy.java
+++ b/src/main/java/com/example/mate/user/domain/DefaultNicknamePolicy.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public class DefaultNicknamePolicy {
 
     private static final int RANDOM_LENGTH = 8;
-    private static final String PREFIX = "DAO-";
+    private static final String PREFIX = "MATE";
 
     public static String generatedRandomString() {
         String randomString = generatedSubStringUUID();

--- a/src/main/java/com/example/mate/user/domain/ReasonType.java
+++ b/src/main/java/com/example/mate/user/domain/ReasonType.java
@@ -1,0 +1,32 @@
+package com.example.mate.user.domain;
+
+import static com.example.mate.user.exception.UserExceptionType.NOT_MATCH_REASON_TYPE;
+
+import com.example.mate.user.exception.UserException;
+import java.util.Arrays;
+
+public enum ReasonType {
+    W0001("서비스에 대한 흥미를 잃었어요"),
+    W0002("사용 빈도가 낮아요"),
+    W0003("이용이 불편하고 장애가 많아요"),
+    W0004("특별한 이유가 없어요"),
+    W0005("기타"),
+    ;
+
+    private final String description;
+
+    ReasonType(String description) {
+        this.description = description;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public static ReasonType getReasonTypeByString(String stringValue) {
+        return Arrays.stream(ReasonType.values())
+                .filter(reasonType -> reasonType.name().equalsIgnoreCase(stringValue))
+                .findFirst()
+                .orElseThrow(() -> new UserException(NOT_MATCH_REASON_TYPE));
+    }
+}

--- a/src/main/java/com/example/mate/user/domain/User.java
+++ b/src/main/java/com/example/mate/user/domain/User.java
@@ -1,0 +1,88 @@
+package com.example.mate.user.domain;
+
+import com.example.mate.common.domain.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id")
+    private String kakaoId;
+
+    private String nickname;
+
+    @Column(name = "profile_url")
+    private String profileUrl;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    private String reasons;
+
+    @Column(columnDefinition = "TEXT", name = "reason_detail")
+    private String reasonDetail;
+
+    @Builder
+    public User(String kakaoId) {
+        this.kakaoId = kakaoId;
+        this.nickname = DefaultNicknamePolicy.generatedRandomString();
+        this.status = UserStatus.ACTIVE_FIRST_LOGIN;
+    }
+
+    public User(Long id, String kakaoId, String nickname, String profileUrl, UserStatus status) {
+        this.id = id;
+        this.kakaoId = kakaoId;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+        this.status = status;
+    }
+
+    public void updateUserInfo(String nickname, String profileUrl) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+        if (status.isFirstLogin()) {
+            status = UserStatus.ACTIVE;
+        }
+    }
+
+    public boolean isDeletedUser() {
+        return status == UserStatus.DELETED;
+    }
+
+    public void updateActiveStatus() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void withdrawWithAddReason(List<String> stringReasonTypeList, String detail) {
+        this.reasons = stringReasonTypeList.stream()
+                .map(ReasonType::getReasonTypeByString)
+                .toList()
+                .toString();
+        this.reasonDetail = detail;
+        this.status = UserStatus.DELETED;
+    }
+}

--- a/src/main/java/com/example/mate/user/domain/UserStatus.java
+++ b/src/main/java/com/example/mate/user/domain/UserStatus.java
@@ -1,0 +1,23 @@
+package com.example.mate.user.domain;
+
+public enum UserStatus {
+    ACTIVE("활성화된 계정"),
+    ACTIVE_FIRST_LOGIN("최초 로그인된 계정"),
+    DELETED("삭제된 계정"),
+    INACTIVE("비활성 계정"),
+    ;
+
+    private final String description;
+
+    public String description() {
+        return description;
+    }
+
+    UserStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean isFirstLogin() {
+        return this == UserStatus.ACTIVE_FIRST_LOGIN;
+    }
+}

--- a/src/main/java/com/example/mate/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/mate/user/domain/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.example.mate.user.domain.repository;
+
+import com.example.mate.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("""
+            SELECT u FROM User u
+             WHERE u.id = :userId
+             AND u.status != 'DELETED'
+            """)
+    Optional<User> findByIdAndStatusIsNotDeleted(Long userId);
+
+    Optional<User> findByKakaoId(String kakao);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/example/mate/user/exception/UserException.java
+++ b/src/main/java/com/example/mate/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.example.mate.user.exception;
+
+
+import com.example.mate.common.exception.BaseException;
+
+public class UserException extends BaseException {
+
+    public UserException(UserExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/example/mate/user/exception/UserExceptionType.java
+++ b/src/main/java/com/example/mate/user/exception/UserExceptionType.java
@@ -1,0 +1,31 @@
+package com.example.mate.user.exception;
+
+import com.example.mate.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum UserExceptionType implements BaseExceptionType {
+    DISABLED_USER("삭제된 사용자입니다.", HttpStatus.NOT_FOUND),
+    NOT_EXIST_USER("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_NICKNAME("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    NOT_MATCH_REASON_TYPE("일치하는 사유 타입이 없습니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    UserExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+}
+

--- a/src/main/java/com/example/mate/user/presentation/UserController.java
+++ b/src/main/java/com/example/mate/user/presentation/UserController.java
@@ -1,7 +1,12 @@
 package com.example.mate.user.presentation;
 
+import com.example.mate.common.response.ApiResponse;
 import com.example.mate.user.application.UserService;
+import com.example.mate.user.application.dto.UserInfoResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserInfoResponseDto>> getUserInfo(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                "LOAD_USER_INFO_SUCCESS",
+                userService.getUserInfoWithId(userId)
+        ));
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
+    #    hibernate:
+    #      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
공통 예외 처리 시스템 및 유저 엔티티 관련 기능 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 프로젝트 기본 설정 (Spring Boot 3.3.2, Java 17)
- ✨ MySQL 데이터베이스 설정 및 도커 컴포즈 구성
- ✨ 공통 모듈 구현 (예외 처리, API 응답 포맷)
- ✨ 유저 도메인 구현 (회원 정보 조회 API)

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #4 #5
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- JPA Auditing 기능을 활용하여 생성/수정 시간 자동 관리
- 예외 처리는 GlobalExceptionHandler를 통해 일관된 포맷으로 처리
- 유저 상태는 ACTIVE, ACTIVE_FIRST_LOGIN, DELETED, INACTIVE로 구분
- 기본 닉네임은 "MATE" 접두사와 8자리 랜덤 문자열로 생성