### PR TITLE
fix: localhost:8080 카카오 로그인으로 이동 제거

### DIFF
--- a/src/main/java/com/example/mate/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mate/common/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/index.html").permitAll()
                         .requestMatchers("/api/v1/auth/reissue").permitAll()
                         .requestMatchers("/oauth2/authorization/kakao").permitAll()
                         .anyRequest().authenticated()
@@ -93,6 +94,7 @@ public class SecurityConfig {
         return new NegatedRequestMatcher(
                 new OrRequestMatcher(
                         new AntPathRequestMatcher("/"),
+                        new AntPathRequestMatcher("/index.html"),
                         new AntPathRequestMatcher("/api/v1/auth/reissue"),
                         new AntPathRequestMatcher("/oauth2/authorization/kakao")
                 )


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
localhost:8080 카카오 로그인으로 이동 제거
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ SecurityConfig에서 index.html 경로 로그인 없어도 접근 가능하게 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2