### PR TITLE
Feature/image upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // AWS
+    implementation 'software.amazon.awssdk:s3:2.25.13'
 }
 
 tasks.test {

--- a/src/main/java/com/example/mate/MateApplication.java
+++ b/src/main/java/com/example/mate/MateApplication.java
@@ -2,12 +2,14 @@ package com.example.mate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class MateApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MateApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(MateApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/example/mate/common/config/S3Config.java
+++ b/src/main/java/com/example/mate/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.example.mate.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final S3Properties properties;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(awsCredentialsProvider())
+                .region(Region.of(properties.region()))
+                .build();
+    }
+
+    private AwsCredentialsProvider awsCredentialsProvider() {
+        AwsBasicCredentials credentials = AwsBasicCredentials
+                .create(properties.accessKey(), properties.secretKey());
+        return StaticCredentialsProvider.create(credentials);
+    }
+}

--- a/src/main/java/com/example/mate/common/config/S3Properties.java
+++ b/src/main/java/com/example/mate/common/config/S3Properties.java
@@ -1,0 +1,14 @@
+package com.example.mate.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public record S3Properties(
+        int cacheTimeSeconds,
+        String bucketName,
+        String accessKey,
+        String secretKey,
+        String imageUrl,
+        String region
+) {
+}

--- a/src/main/java/com/example/mate/upload/application/ImageClient.java
+++ b/src/main/java/com/example/mate/upload/application/ImageClient.java
@@ -1,0 +1,8 @@
+package com.example.mate.upload.application;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageClient {
+
+    String upload(String objectKey, MultipartFile file);
+}

--- a/src/main/java/com/example/mate/upload/application/UploadService.java
+++ b/src/main/java/com/example/mate/upload/application/UploadService.java
@@ -1,0 +1,20 @@
+package com.example.mate.upload.application;
+
+import com.example.mate.upload.application.dto.UploadImageResponseDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class UploadService {
+
+    private final ImageClient imageClient;
+
+    public UploadImageResponseDto upload(MultipartFile file) {
+        String objectKey = UUID.randomUUID().toString();
+        String imageUrl = imageClient.upload(objectKey, file);
+        return UploadImageResponseDto.of(imageUrl);
+    }
+}

--- a/src/main/java/com/example/mate/upload/application/dto/UploadImageResponseDto.java
+++ b/src/main/java/com/example/mate/upload/application/dto/UploadImageResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.mate.upload.application.dto;
+
+public record UploadImageResponseDto(
+        String imageUrl
+) {
+
+    public static UploadImageResponseDto of(String imageUrl) {
+        return new UploadImageResponseDto(imageUrl);
+    }
+}

--- a/src/main/java/com/example/mate/upload/exception/UploadException.java
+++ b/src/main/java/com/example/mate/upload/exception/UploadException.java
@@ -1,0 +1,10 @@
+package com.example.mate.upload.exception;
+
+import com.example.mate.common.exception.BaseException;
+
+public class UploadException extends BaseException {
+
+    public UploadException(UploadExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/example/mate/upload/exception/UploadExceptionType.java
+++ b/src/main/java/com/example/mate/upload/exception/UploadExceptionType.java
@@ -1,0 +1,28 @@
+package com.example.mate.upload.exception;
+
+import com.example.mate.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum UploadExceptionType implements BaseExceptionType {
+    FILE_ENCODE_FAIL("파일 인코딩 실패", HttpStatus.BAD_REQUEST),
+    UPLOAD_IMAGE_FAIL("이미지 업로드 실패", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    UploadExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+}

--- a/src/main/java/com/example/mate/upload/infrastructure/s3/S3ImageClient.java
+++ b/src/main/java/com/example/mate/upload/infrastructure/s3/S3ImageClient.java
@@ -1,0 +1,27 @@
+package com.example.mate.upload.infrastructure.s3;
+
+import com.example.mate.common.config.S3Properties;
+import com.example.mate.upload.application.ImageClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageClient implements ImageClient {
+
+    private final S3Uploader s3Uploader;
+    private final S3Properties properties;
+
+    @Override
+    public String upload(String objectKey, MultipartFile file) {
+        String bucketName = properties.bucketName();
+        int cacheTimeSeconds = properties.cacheTimeSeconds();
+        s3Uploader.upload(cacheTimeSeconds, bucketName, objectKey, file);
+        return generatedImageUrl(objectKey);
+    }
+
+    private String generatedImageUrl(String objectKey) {
+        return properties.imageUrl() + objectKey;
+    }
+}

--- a/src/main/java/com/example/mate/upload/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/com/example/mate/upload/infrastructure/s3/S3Uploader.java
@@ -1,0 +1,52 @@
+package com.example.mate.upload.infrastructure.s3;
+
+import static com.example.mate.upload.exception.UploadExceptionType.FILE_ENCODE_FAIL;
+import static com.example.mate.upload.exception.UploadExceptionType.UPLOAD_IMAGE_FAIL;
+
+import com.example.mate.upload.exception.UploadException;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private static final String CACHE_CONTROL_PREFIX = "max-age=";
+
+    private final S3Client s3Client;
+
+    public void upload(int cacheTimeSeconds, String bucketName, String key, MultipartFile file) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(file.getContentType())
+                .cacheControl(generateCacheControlHeader(cacheTimeSeconds))
+                .build();
+        putObject(request, file);
+    }
+
+    private String generateCacheControlHeader(int cacheTimeSeconds) {
+        return CACHE_CONTROL_PREFIX + cacheTimeSeconds;
+    }
+
+    private void putObject(PutObjectRequest request, MultipartFile file) {
+        try {
+            s3Client.putObject(request, RequestBody.fromBytes(getBytes(file)));
+        } catch (Exception ex) {
+            throw new UploadException(UPLOAD_IMAGE_FAIL);
+        }
+    }
+
+    private byte[] getBytes(MultipartFile file) {
+        try {
+            return file.getBytes();
+        } catch (IOException ex) {
+            throw new UploadException(FILE_ENCODE_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/example/mate/upload/presentation/UploadController.java
+++ b/src/main/java/com/example/mate/upload/presentation/UploadController.java
@@ -1,0 +1,29 @@
+package com.example.mate.upload.presentation;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.upload.application.UploadService;
+import com.example.mate.upload.application.dto.UploadImageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/uploads")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final UploadService uploadService;
+
+    @PostMapping("/images")
+    public ResponseEntity<ApiResponse<UploadImageResponseDto>> uploadImage(
+            @RequestParam("file") MultipartFile file
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                uploadService.upload(file)
+        ));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -83,3 +83,13 @@ security:
     secret-key: ${JWT_SECRET}
     access-expired: 987654321
     refresh-expired: 987654321
+
+cloud:
+  aws:
+    s3:
+      cache-time-seconds: 2592000  # 30일
+      bucket-name: ${S3_BUCKET_NAME}
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+      image-url: ${S3_IMAGE_URL}
+      region: ${S3_REGION}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
AWS S3를 활용한 이미지 업로드 기능을 구현했습니다. 
사용자가 업로드한 이미지를 S3에 저장하고 해당 URL을 반환하는 API를 제공합니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ AWS S3 연동을 위한 의존성 및 설정 추가
- ✨ S3 이미지 업로드 클라이언트 구현
- ✨ 이미지 업로드 API 엔드포인트 구현 (POST /api/v1/upload/image)
- ✨ 이미지 업로드 관련 예외 처리 구현
- ✨ 업로드된 이미지의 캐시 컨트롤 설정 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #26 
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 이미지 파일명은 UUID를 사용하여 고유값 생성
- 현재 지원하는 이미지 형식: jpg, jpeg, png, gif
- 업로드된 이미지의 캐시 유효 기간은 1년으로 설정