### PR TITLE
fix: 유저 정보 변경 API

### DIFF
--- a/src/main/java/com/example/mate/user/application/UserService.java
+++ b/src/main/java/com/example/mate/user/application/UserService.java
@@ -57,9 +57,13 @@ public class UserService {
     public UserInfoResponseDto updateUser(UserInfoRequestDto request, Long userId) {
         User findUser = userRepository.findByIdAndStatusIsNotDeleted(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
-        findUser.updateUserInfoAll(
+
+        findUser.updateUserInfoBasic(
                 request.nickname(),
-                request.profileUrl(),
+                request.profileUrl()
+        );
+
+        findUser.updateUserInfoAll(
                 request.jobType(),
                 request.jobYear(),
                 request.intro(),

--- a/src/main/java/com/example/mate/user/domain/User.java
+++ b/src/main/java/com/example/mate/user/domain/User.java
@@ -88,9 +88,20 @@ public class User extends BaseTimeEntity {
         }
     }
 
-    public void updateUserInfoAll(
+    public void updateUserInfoBasic(
             String nickname,
-            String profileUrl,
+            String profileUrl
+    ) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+    }
+
+    public void updateUserInfoAll(
             UserJobType jobType,
             Integer jobYear,
             String intro,
@@ -99,15 +110,6 @@ public class User extends BaseTimeEntity {
             String githubUrl,
             String blogUrl
     ) {
-
-        if (nickname != null) {
-            this.nickname = nickname;
-        }
-
-        if (profileUrl != null) {
-            this.profileUrl = profileUrl;
-        }
-
         if (status.isFirstLogin()) {
             status = UserStatus.ACTIVE;
         }
@@ -164,7 +166,7 @@ public class User extends BaseTimeEntity {
         userStacks.add(userStack);
     }
 
-    public void removeTag(Stack stack) {
+    public void removeStack(Stack stack) {
         userStacks.removeIf(userStack -> userStack.getStack().equals(stack));
     }
 }

--- a/src/main/java/com/example/mate/user/presentation/UserController.java
+++ b/src/main/java/com/example/mate/user/presentation/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
         ));
     }
 
-    @PatchMapping("/{userId}")
+    @PatchMapping
     public ResponseEntity<UserInfoResponseDto> updateOUserInfo(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserInfoRequestDto request


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
유저 정보 변경 API 수정 #30 
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ user 도메인 유저 정보 업데이트 분리 및 함수명 변경
- ✨ user controller patchMapping userId 삭제
- ✨ user service 유저 정보 업데이트 분리

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2