### PR TITLE
feat: Proposal API 구현

### DIFF
--- a/src/main/java/com/example/mate/proposal/application/ProposalService.java
+++ b/src/main/java/com/example/mate/proposal/application/ProposalService.java
@@ -1,0 +1,75 @@
+package com.example.mate.proposal.application;
+
+import com.example.mate.proposal.application.dto.ProposalResponseDto;
+import com.example.mate.proposal.domain.Proposal;
+import com.example.mate.proposal.domain.repository.ProposalRepository;
+import com.example.mate.proposal.exception.ProposalException;
+import com.example.mate.user.application.UserService;
+import com.example.mate.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.example.mate.proposal.exception.ProposalExceptionType.NOT_EXIST_Proposal;
+
+
+@Service
+@RequiredArgsConstructor
+public class ProposalService {
+
+    private final ProposalRepository proposalRepository;
+    private final UserService userService;
+
+    @Transactional
+    public ProposalResponseDto createProposal(Long userId, ProposalResponseDto request) {
+        User findUser = userService.getUserById(userId);
+
+        Proposal newProposal = Proposal.builder()
+                .user(findUser)
+                .title(request.title())
+                .description(request.description())
+                .build();
+
+        Proposal saveProposal = proposalRepository.save(newProposal);
+
+        return ProposalResponseDto.of(saveProposal);
+    }
+
+    public List<ProposalResponseDto> getProposalByUserId(Long userId) {
+        List<Proposal> findProposals = proposalRepository.findByUserId(userId);
+
+        return ProposalResponseDto.of(findProposals);
+    }
+
+    public ProposalResponseDto getProposalByIdAndUserId(Long userId, Long ProposalId) {
+        Proposal findProposal = proposalRepository.findByIdAndUserId(ProposalId, userId)
+                .orElseThrow(() -> new ProposalException(NOT_EXIST_Proposal));
+
+        return ProposalResponseDto.of(findProposal);
+    }
+
+    @Transactional
+    public ProposalResponseDto updateProposalByIdAndUserId(Long userId, Long ProposalId, ProposalResponseDto request) {
+        Proposal findProposal = proposalRepository.findByIdAndUserId(ProposalId, userId)
+                .orElseThrow(() -> new ProposalException(NOT_EXIST_Proposal));
+
+        findProposal.updateProposalInfo(
+                request.title(),
+                request.description()
+        );
+
+        Proposal updateProposal = proposalRepository.save(findProposal);
+
+        return ProposalResponseDto.of(updateProposal);
+    }
+
+    @Transactional
+    public void deleteProposalByIdAndUserId(Long userId, Long ProposalId) {
+        Proposal findProposal = proposalRepository.findByIdAndUserId(ProposalId, userId)
+                .orElseThrow(() -> new ProposalException(NOT_EXIST_Proposal));
+
+        proposalRepository.delete(findProposal);
+    }
+}

--- a/src/main/java/com/example/mate/proposal/application/dto/ProposalResponseDto.java
+++ b/src/main/java/com/example/mate/proposal/application/dto/ProposalResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.mate.proposal.application.dto;
+
+import com.example.mate.proposal.domain.Proposal;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public record ProposalResponseDto(
+        String title,
+        String description
+) {
+
+    public static ProposalResponseDto of(Proposal proposal) {
+        return new ProposalResponseDto(
+                proposal.getTitle(),
+                proposal.getDescription()
+        );
+    }
+
+    public static List<ProposalResponseDto> of(List<Proposal> proposals) {
+        return proposals.stream()
+                .map(ProposalResponseDto::of)
+                .collect(Collectors.toList());
+    }
+}
+
+

--- a/src/main/java/com/example/mate/proposal/domain/Proposal.java
+++ b/src/main/java/com/example/mate/proposal/domain/Proposal.java
@@ -1,0 +1,47 @@
+package com.example.mate.proposal.domain;
+
+import com.example.mate.common.domain.BaseTimeEntity;
+import com.example.mate.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "Proposal")
+public class Proposal extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "proposal_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(columnDefinition = "TEXT", name = "description")
+    private String description;
+
+    @Builder
+    public Proposal(User user, String title, String description) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+    }
+
+    public void updateProposalInfo(String title, String description) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
+}

--- a/src/main/java/com/example/mate/proposal/domain/repository/ProposalRepository.java
+++ b/src/main/java/com/example/mate/proposal/domain/repository/ProposalRepository.java
@@ -1,0 +1,13 @@
+package com.example.mate.proposal.domain.repository;
+
+import com.example.mate.proposal.domain.Proposal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+    List<Proposal> findByUserId(Long userId);
+
+    Optional<Proposal> findByIdAndUserId(Long proposalId, Long userId);
+}

--- a/src/main/java/com/example/mate/proposal/exception/ProposalException.java
+++ b/src/main/java/com/example/mate/proposal/exception/ProposalException.java
@@ -1,0 +1,10 @@
+package com.example.mate.proposal.exception;
+
+import com.example.mate.common.exception.BaseException;
+
+public class ProposalException extends BaseException {
+
+    public ProposalException(ProposalExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/example/mate/proposal/exception/ProposalExceptionType.java
+++ b/src/main/java/com/example/mate/proposal/exception/ProposalExceptionType.java
@@ -1,0 +1,27 @@
+package com.example.mate.proposal.exception;
+
+import com.example.mate.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ProposalExceptionType implements BaseExceptionType {
+    NOT_EXIST_Proposal("존재하지 않는 제안서입니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    ProposalExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+}

--- a/src/main/java/com/example/mate/proposal/presentation/ProposalController.java
+++ b/src/main/java/com/example/mate/proposal/presentation/ProposalController.java
@@ -1,0 +1,68 @@
+package com.example.mate.proposal.presentation;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.proposal.application.ProposalService;
+import com.example.mate.proposal.application.dto.ProposalResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/proposals")
+@RequiredArgsConstructor
+public class ProposalController {
+
+    private final ProposalService proposalService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ProposalResponseDto>> createProposal(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ProposalResponseDto request
+    ) {
+        ProposalResponseDto proposalResponseDto = proposalService.createProposal(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>(proposalResponseDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProposalResponseDto>>> getProposal(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                proposalService.getProposalByUserId(userId))
+        );
+    }
+
+    @GetMapping("/{proposalId}")
+    public ResponseEntity<ApiResponse<ProposalResponseDto>> getProposalById(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long proposalId
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                proposalService.getProposalByIdAndUserId(userId, proposalId))
+        );
+    }
+
+    @PatchMapping("/{proposalId}")
+    public ResponseEntity<ApiResponse<ProposalResponseDto>> updateProposalById(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ProposalResponseDto request,
+            @PathVariable Long proposalId
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                proposalService.updateProposalByIdAndUserId(userId, proposalId, request))
+        );
+    }
+
+    @DeleteMapping("/{proposalId}")
+    public ResponseEntity<ApiResponse<ProposalResponseDto>> deleteProposalById(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long proposalId
+    ) {
+        proposalService.deleteProposalByIdAndUserId(userId, proposalId);
+        return ResponseEntity.ok(null);
+    }
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
Proposal CRUD 할 수 있는 API 구현
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ Proposal 도메인 구현
- ✨ Proposal 컨트롤러 구현 CRUD
- ✨ Proposal 예외 구현
- ✨ ProposalRepository 구현
- ✨ ProposalResponseDto 구현
- ✨ Proposal 서비스 구현

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2