### PR TITLE
feat: 회원가입시 프로필 url 저장 추가 및 AT 닉네임, 프로필 url 추가

### DIFF
--- a/src/main/java/com/example/mate/auth/application/AuthService.java
+++ b/src/main/java/com/example/mate/auth/application/AuthService.java
@@ -20,8 +20,8 @@ public class AuthService {
     private final TokenExtractor tokenExtractor;
     private final TokenRepository tokenRepository;
 
-    public TokenResponseDto loginOrRegister(String oAuthId) {
-        User findUser = userService.getOrRegisterByOAuthId(oAuthId);
+    public TokenResponseDto loginOrRegister(String oAuthId, String kakaoImageUrl) {
+        User findUser = userService.getOrRegisterByOAuthId(oAuthId, kakaoImageUrl);
 
         Token newToken = Token.builder()
                 .userId(findUser.getId())
@@ -29,7 +29,11 @@ public class AuthService {
 
         tokenRepository.save(newToken);
 
-        String accessToken = tokenProvider.generatedAccessToken(newToken.getUserId());
+        String accessToken = tokenProvider.generatedAccessToken(
+                newToken.getUserId(),
+                findUser.getProfileUrl(),
+                findUser.getNickname()
+        );
         String refreshToken = tokenProvider.generatedRefreshToken(newToken.getTokenId());
         return TokenResponseDto.of(accessToken, refreshToken);
     }
@@ -48,7 +52,13 @@ public class AuthService {
 
         tokenRepository.save(newToken);
 
-        String accessToken = tokenProvider.generatedAccessToken(newToken.getUserId());
+        User findUser = userService.getUserById(newToken.getUserId());
+
+        String accessToken = tokenProvider.generatedAccessToken(
+                newToken.getUserId(),
+                findUser.getProfileUrl(),
+                findUser.getNickname()
+        );
         String refreshToken = tokenProvider.generatedRefreshToken(newToken.getTokenId());
         return TokenResponseDto.of(accessToken, refreshToken);
     }

--- a/src/main/java/com/example/mate/auth/application/TokenProvider.java
+++ b/src/main/java/com/example/mate/auth/application/TokenProvider.java
@@ -2,7 +2,7 @@ package com.example.mate.auth.application;
 
 public interface TokenProvider {
 
-    String generatedAccessToken(Long userId);
+    String generatedAccessToken(Long userId, String userProfileUrl, String userNickname);
 
     String generatedRefreshToken(String tokenId);
 }

--- a/src/main/java/com/example/mate/auth/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/com/example/mate/auth/infrastructure/jwt/JwtProvider.java
@@ -15,6 +15,8 @@ import java.util.Date;
 public class JwtProvider implements TokenProvider {
 
     private static final String USER_ID = "user_id";
+    private static final String USER_URL = "user_url";
+    private static final String USER_NICKNAME = "user_nickname";
     private static final String TOKEN_ID = "token_id";
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REFRESH_TOKEN = "refresh_token";
@@ -28,8 +30,10 @@ public class JwtProvider implements TokenProvider {
     }
 
     @Override
-    public String generatedAccessToken(Long userId) {
+    public String generatedAccessToken(Long userId, String userProfileUrl, String userNickname) {
         Claims claims = generatedClaims(USER_ID, userId);
+        claims.put(USER_URL, userProfileUrl);
+        claims.put(USER_NICKNAME, userNickname);
         return generatedToken(claims, ACCESS_TOKEN, jwtProperties.getAccessExpired());
     }
 
@@ -47,7 +51,7 @@ public class JwtProvider implements TokenProvider {
 
     private String generatedToken(Claims claims, String subject, Long exp) {
         long now = System.currentTimeMillis();
-        
+
         return Jwts.builder()
                 .setClaims(claims)                   //사용자 정의 데이터
                 .setSubject(subject)                 //jwt 소유자 사용자의 식별자로 사용된다

--- a/src/main/java/com/example/mate/auth/infrastructure/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/example/mate/auth/infrastructure/security/oauth/OAuthSuccessHandler.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
@@ -43,7 +44,12 @@ public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
             Authentication authentication
     ) throws IOException, ServletException {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        TokenResponseDto tokenResponseDto = authService.loginOrRegister(oAuth2User.getName());
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        String profileImageUrl = (String) properties.get("profile_image");
+
+        TokenResponseDto tokenResponseDto = authService.loginOrRegister(oAuth2User.getName(), profileImageUrl);
         ResponseCookie cookie = cookieHandler.createCookie(
                 REFRESH_TOKEN,
                 tokenResponseDto.refreshToken()

--- a/src/main/java/com/example/mate/user/application/UserService.java
+++ b/src/main/java/com/example/mate/user/application/UserService.java
@@ -35,10 +35,10 @@ public class UserService {
     }
 
     @Transactional
-    public User getOrRegisterByOAuthId(String oAuthId) {
+    public User getOrRegisterByOAuthId(String oAuthId, String kakaoImageUrl) {
         return userRepository.findByKakaoId(oAuthId)
                 .map(this::activateIfDeleted)
-                .orElseGet(() -> registerNewUserAndPublish(oAuthId));
+                .orElseGet(() -> registerNewUserAndPublish(oAuthId, kakaoImageUrl));
     }
 
     private User activateIfDeleted(User user) {
@@ -48,8 +48,8 @@ public class UserService {
         return user;
     }
 
-    private User registerNewUserAndPublish(String oAuthId) {
-        User newUser = User.builder().kakaoId(oAuthId).build();
+    private User registerNewUserAndPublish(String oAuthId, String profileUrl) {
+        User newUser = User.builder().kakaoId(oAuthId).profileUrl(profileUrl).build();
         User saveUser = userRepository.save(newUser);
         return saveUser;
     }
@@ -86,6 +86,11 @@ public class UserService {
         User updateUser = userRepository.save(findUser);
         return UserInfoResponseDto.of(updateUser);
     }
+
+//    @Transactional
+//    public User deleteUser(Long userId) {
+//        User findUser = getUserById(userId);
+//    }
 
     private List<PopularityUserResponseDto> getPopularityUsers() {
         Pageable pageRequest = PageRequest.of(0, 5, Sort.by(Sort.Order.desc("count")));

--- a/src/main/java/com/example/mate/user/domain/User.java
+++ b/src/main/java/com/example/mate/user/domain/User.java
@@ -62,8 +62,9 @@ public class User extends BaseTimeEntity {
     private List<UserStack> userStacks = new ArrayList<>();
 
     @Builder
-    public User(String kakaoId) {
+    public User(String kakaoId, String profileUrl) {
         this.kakaoId = kakaoId;
+        this.profileUrl = profileUrl;
         this.nickname = DefaultNicknamePolicy.generatedRandomString();
         this.status = UserStatus.ACTIVE_FIRST_LOGIN;
     }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
회원가입시 프로필 url 저장 추가 및 AT 닉네임, 프로필 url 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ AuthService accessToken 이미지 url, 닉네임 추가
- ✨ JwtProvider accessToken 이미지 url, 닉네임 추가
- ✨ OAuthSuccessHandler 카카오 이미지 추출
- ✨ TokenProvider 프로필 url, 닉네임 값 추가
- ✨ User 도메인 프로필 url 추가
- ✨ UserService 신규 회원 저장시 프로필 url도 같이 저장

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2