### PR TITLE
feat: cahtread 기능 추가

### DIFF
--- a/src/main/java/com/example/mate/chat/application/ChatMessageCountPublisher.java
+++ b/src/main/java/com/example/mate/chat/application/ChatMessageCountPublisher.java
@@ -1,0 +1,6 @@
+package com.example.mate.chat.application;
+
+public interface ChatMessageCountPublisher {
+
+    void execute(Long senderId, String roomToken, Long messageCount);
+}

--- a/src/main/java/com/example/mate/chat/application/ChatMessageService.java
+++ b/src/main/java/com/example/mate/chat/application/ChatMessageService.java
@@ -3,8 +3,10 @@ package com.example.mate.chat.application;
 import com.example.mate.chat.application.dto.ChatMessageDto;
 import com.example.mate.chat.application.dto.ChatMessageInfoDto;
 import com.example.mate.chat.domain.ChatMessage;
+import com.example.mate.chat.domain.ChatRead;
 import com.example.mate.chat.domain.ChatUser;
 import com.example.mate.chat.domain.repository.ChatMessageRepository;
+import com.example.mate.chat.domain.repository.ChatReadRepository;
 import com.example.mate.chat.domain.repository.ChatUserRepository;
 import com.example.mate.chat.exception.ChatException;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +21,14 @@ public class ChatMessageService {
 
     private final ChatUserRepository chatUserRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatReadRepository chatReadRepository;
     private final ChatMessageEventPublisher messageEventPublisher;
+    private final ChatMessageCountPublisher chatMessageCountPublisher;
 
     public void sendChatMessage(Long userId, ChatMessageDto message) {
         ChatMessageInfoDto messageInfoDto = createAndSaveMessage(userId, message);
+        Long messageCount = chatReadRepository.countByRoomTokenAndSenderId(message.roomToken(), userId);
+        chatMessageCountPublisher.execute(messageInfoDto.senderId(), messageInfoDto.roomToken(), messageCount);
         messageEventPublisher.execute(messageInfoDto);
     }
 
@@ -46,6 +52,12 @@ public class ChatMessageService {
                 .message(message.message())
                 .build();
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+        ChatRead chatRead = ChatRead.builder()
+                .roomToken(message.roomToken())
+                .messageId(savedChatMessage.getId())
+                .senderId(userId)
+                .build();
+        chatReadRepository.save(chatRead);
         return ChatMessageInfoDto.of(savedChatMessage, findUser);
     }
 

--- a/src/main/java/com/example/mate/chat/domain/ChatRead.java
+++ b/src/main/java/com/example/mate/chat/domain/ChatRead.java
@@ -1,0 +1,39 @@
+package com.example.mate.chat.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Document(collection = "chat_read")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRead {
+
+    @Id
+    @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+    private ObjectId id;
+
+    @Indexed
+    @Field("room_token")
+    private String roomToken;
+
+    @Field(value = "message_id")
+    private ObjectId messageId;
+
+    @Field("sender_id")
+    private Long senderId;
+
+    @Builder
+    public ChatRead(String roomToken, ObjectId messageId, Long senderId) {
+        this.roomToken = roomToken;
+        this.messageId = messageId;
+        this.senderId = senderId;
+    }
+}

--- a/src/main/java/com/example/mate/chat/domain/repository/ChatReadRepository.java
+++ b/src/main/java/com/example/mate/chat/domain/repository/ChatReadRepository.java
@@ -1,0 +1,11 @@
+package com.example.mate.chat.domain.repository;
+
+import com.example.mate.chat.domain.ChatRead;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatReadRepository extends MongoRepository<ChatRead, ObjectId> {
+    long countByRoomTokenAndSenderId(String roomToken, Long senderId);
+
+    void deleteByRoomToken(String roomToken);
+}

--- a/src/main/java/com/example/mate/chat/infrastructure/stomp/StompMessageCountPublisher.java
+++ b/src/main/java/com/example/mate/chat/infrastructure/stomp/StompMessageCountPublisher.java
@@ -1,0 +1,20 @@
+package com.example.mate.chat.infrastructure.stomp;
+
+import com.example.mate.chat.application.ChatMessageCountPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompMessageCountPublisher implements ChatMessageCountPublisher {
+
+    private static final String SUBSCRIBE_URL = "/sub/count/chat-rooms/";
+
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @Override
+    public void execute(Long senderId, String roomToken, Long messageCount) {
+        messagingTemplate.convertAndSend(SUBSCRIBE_URL + senderId + "/" + roomToken, messageCount);
+    }
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
읽지 않은 메시지 카운트 로직 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ ChatRead 도메인 추가
- ✨ ChatReadRepository 추가
- ✨ ChatMessageCountPublisher 추가
- ✨ StompMessageCountPublisher 추가
- ✨ ChatMessageService 채팅 카운트 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2