### PR TITLE
refactor : 채팅 카운트 및 마지막 채팅 로직 변경

### DIFF
--- a/src/main/java/com/example/mate/chat/application/ChatMessageCountPublisher.java
+++ b/src/main/java/com/example/mate/chat/application/ChatMessageCountPublisher.java
@@ -1,6 +1,8 @@
 package com.example.mate.chat.application;
 
+import com.example.mate.chat.application.dto.ChatLastMessageAndCountDto;
+
 public interface ChatMessageCountPublisher {
 
-    void execute(Long senderId, String roomToken, Long messageCount);
+    void execute(Long senderId, String roomToken, ChatLastMessageAndCountDto chatLastMessageAndCountDto);
 }

--- a/src/main/java/com/example/mate/chat/application/ChatMessageService.java
+++ b/src/main/java/com/example/mate/chat/application/ChatMessageService.java
@@ -1,8 +1,10 @@
 package com.example.mate.chat.application;
 
+import com.example.mate.chat.application.dto.ChatLastMessageAndCountDto;
 import com.example.mate.chat.application.dto.ChatMessageDto;
 import com.example.mate.chat.application.dto.ChatMessageInfoDto;
 import com.example.mate.chat.application.dto.ChatMessageInfoDto.EnterAndLeaveMessage;
+import com.example.mate.chat.application.dto.ChatMessageResponseDto;
 import com.example.mate.chat.domain.*;
 import com.example.mate.chat.domain.repository.ChatMessageRepository;
 import com.example.mate.chat.domain.repository.ChatReadRepository;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.example.mate.chat.domain.MessageType.*;
 import static com.example.mate.chat.exception.ChatExceptionType.INVALID_CHAT_USER_ID_EXCEPTION;
@@ -28,11 +31,31 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageEventPublisher messageEventPublisher;
     private final ChatMessageCountPublisher chatMessageCountPublisher;
+    private final ChatService chatService;
 
     public void sendChatMessage(Long userId, ChatMessageDto message) {
         ChatMessageInfoDto messageInfoDto = createAndSaveMessage(userId, message);
+
+        ChatRoom chatRoomInfo = chatRoomRepository.findChatRoomBytokenId(message.roomToken());
+
+        Long recUserId = -1L;
+        if (chatRoomInfo.getUser1Id() == userId) {
+            recUserId = chatRoomInfo.getUser2Id();
+        } else {
+            recUserId = chatRoomInfo.getUser1Id();
+        }
+
+        ChatMessageResponseDto responseDto = chatService.getRecentMessagesByRoomToken(message.roomToken());
+        List<ChatMessageInfoDto> messages = responseDto.messages();
+        String latestMessage = messages.get(0).message();
+
+
         Long messageCount = chatReadRepository.countByRoomTokenAndSenderId(message.roomToken(), userId);
-        chatMessageCountPublisher.execute(messageInfoDto.senderId(), messageInfoDto.roomToken(), messageCount);
+        ChatLastMessageAndCountDto dto = new ChatLastMessageAndCountDto(latestMessage, messageCount);
+        if (recUserId != null) {
+            chatMessageCountPublisher.execute(recUserId, messageInfoDto.roomToken(), dto);
+        }
+
         messageEventPublisher.execute(messageInfoDto);
     }
 

--- a/src/main/java/com/example/mate/chat/application/ChatService.java
+++ b/src/main/java/com/example/mate/chat/application/ChatService.java
@@ -1,9 +1,6 @@
 package com.example.mate.chat.application;
 
-import com.example.mate.chat.application.dto.ChatMessageInfoDto;
-import com.example.mate.chat.application.dto.ChatMessageResponseDto;
-import com.example.mate.chat.application.dto.ChatRoomListDto;
-import com.example.mate.chat.application.dto.ChatRoomTokenDto;
+import com.example.mate.chat.application.dto.*;
 import com.example.mate.chat.domain.ChatMessage;
 import com.example.mate.chat.domain.ChatRoom;
 import com.example.mate.chat.domain.ChatUser;
@@ -67,7 +64,6 @@ public class ChatService {
     }
 
     public ChatMessageResponseDto getMessagesByRoomToken(String roomToken, Long userId, ObjectId cursorId, int limit) {
-        chatReadRepository.deleteByRoomToken(roomToken);
         ChatRoom chatRoomInfo = chatRoomRepository.findChatRoomBytokenId(roomToken);
         Long otherUser;
         if (userId == chatRoomInfo.getUser1Id()) {
@@ -75,8 +71,15 @@ public class ChatService {
         } else {
             otherUser = chatRoomInfo.getUser1Id();
         }
+        chatReadRepository.deleteByRoomTokenAndSenderId(roomToken, otherUser);
+
+        ChatMessageResponseDto responseDto = getRecentMessagesByRoomToken(roomToken);
+        List<ChatMessageInfoDto> messages = responseDto.messages();
+        String latestMessage = messages.get(0).message();
+
         Long messageCount = chatReadRepository.countByRoomTokenAndSenderId(roomToken, otherUser);
-        chatMessageCountPublisher.execute(otherUser, roomToken, messageCount);
+        ChatLastMessageAndCountDto dto = new ChatLastMessageAndCountDto(latestMessage, messageCount);
+        chatMessageCountPublisher.execute(otherUser, roomToken, dto);
 
         List<ChatMessage> pagedChatMessageList = getPagedChatMessages(roomToken, cursorId, limit);
         boolean hasNext = checkHasNextPage(pagedChatMessageList, limit);

--- a/src/main/java/com/example/mate/chat/application/dto/ChatLastMessageAndCountDto.java
+++ b/src/main/java/com/example/mate/chat/application/dto/ChatLastMessageAndCountDto.java
@@ -1,0 +1,7 @@
+package com.example.mate.chat.application.dto;
+
+public record ChatLastMessageAndCountDto(
+        String message,
+        Long messageCount
+) {
+}

--- a/src/main/java/com/example/mate/chat/domain/repository/ChatReadRepository.java
+++ b/src/main/java/com/example/mate/chat/domain/repository/ChatReadRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 public interface ChatReadRepository extends MongoRepository<ChatRead, ObjectId> {
     long countByRoomTokenAndSenderId(String roomToken, Long senderId);
 
-    void deleteByRoomToken(String roomToken);
+    void deleteByRoomTokenAndSenderId(String roomToken, Long senderId);
 }

--- a/src/main/java/com/example/mate/chat/infrastructure/stomp/StompMessageCountPublisher.java
+++ b/src/main/java/com/example/mate/chat/infrastructure/stomp/StompMessageCountPublisher.java
@@ -1,6 +1,7 @@
 package com.example.mate.chat.infrastructure.stomp;
 
 import com.example.mate.chat.application.ChatMessageCountPublisher;
+import com.example.mate.chat.application.dto.ChatLastMessageAndCountDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,7 @@ public class StompMessageCountPublisher implements ChatMessageCountPublisher {
     private final SimpMessageSendingOperations messagingTemplate;
 
     @Override
-    public void execute(Long senderId, String roomToken, Long messageCount) {
-        messagingTemplate.convertAndSend(SUBSCRIBE_URL + senderId + "/" + roomToken, messageCount);
+    public void execute(Long senderId, String roomToken, ChatLastMessageAndCountDto chatLastMessageAndCountDto) {
+        messagingTemplate.convertAndSend(SUBSCRIBE_URL + senderId + "/" + roomToken, chatLastMessageAndCountDto);
     }
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
채팅 카운트 및 마지막 채팅 로직 변경
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ ChatMessageCountPublisher 파라미터 변경
- ✨ ChatMessageService 읽지 않은 채팅 갯수 및 마지막 채팅 추가
- ✨ ChatReadRepository 삭제 파라미터 추가
- ✨ ChatService 삭제 파라미터 추가
- ✨ StompMessageCountPublisher 읽지 않은 채팅 갯수 및 마지막 채팅 추가
- ✨ ChatLastMessageAndCountDto 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2