### PR TITLE
refactor : 채팅 전송 websocket으로 변경

### DIFF
--- a/src/main/java/com/example/mate/auth/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/com/example/mate/auth/infrastructure/jwt/JwtExtractor.java
@@ -53,7 +53,7 @@ public class JwtExtractor implements TokenExtractor {
         throw new AuthException(INVALID_TOKEN_TYPE);
     }
 
-    private Claims parseClaim(String token) {
+    public Claims parseClaim(String token) {
         try {
             return jwtParser.parseClaimsJws(token)
                     .getBody();

--- a/src/main/java/com/example/mate/chat/application/ChatService.java
+++ b/src/main/java/com/example/mate/chat/application/ChatService.java
@@ -75,12 +75,15 @@ public class ChatService {
 
         ChatMessageResponseDto responseDto = getRecentMessagesByRoomToken(roomToken);
         List<ChatMessageInfoDto> messages = responseDto.messages();
-        String latestMessage = messages.get(0).message();
-        String createdAt = messages.get(0).createdAt();
 
-        Long messageCount = chatReadRepository.countByRoomTokenAndSenderId(roomToken, otherUser);
-        ChatLastMessageAndCountDto dto = new ChatLastMessageAndCountDto(latestMessage, messageCount, createdAt);
-        chatMessageCountPublisher.execute(otherUser, roomToken, dto);
+        if (!messages.isEmpty()) {
+            String latestMessage = messages.get(0).message();
+            String createdAt = messages.get(0).createdAt();
+
+            Long messageCount = chatReadRepository.countByRoomTokenAndSenderId(roomToken, otherUser);
+            ChatLastMessageAndCountDto dto = new ChatLastMessageAndCountDto(latestMessage, messageCount, createdAt);
+            chatMessageCountPublisher.execute(otherUser, roomToken, dto);
+        }
 
         List<ChatMessage> pagedChatMessageList = getPagedChatMessages(roomToken, cursorId, limit);
         boolean hasNext = checkHasNextPage(pagedChatMessageList, limit);

--- a/src/main/java/com/example/mate/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/mate/chat/presentation/ChatController.java
@@ -1,5 +1,6 @@
 package com.example.mate.chat.presentation;
 
+import com.example.mate.auth.infrastructure.jwt.JwtExtractor;
 import com.example.mate.chat.application.ChatMessageService;
 import com.example.mate.chat.application.ChatService;
 import com.example.mate.chat.application.dto.ChatMessageDto;
@@ -8,9 +9,12 @@ import com.example.mate.chat.application.dto.ChatRoomListDto;
 import com.example.mate.chat.application.dto.ChatRoomTokenDto;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.product.application.ProductService;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +28,7 @@ public class ChatController {
     private final ProductService productService;
     private final ChatService chatService;
     private final ChatMessageService chatMessageService;
+    private final JwtExtractor jwtExtractor;
 
     @PostMapping("/greet")
     public ResponseEntity<Void> enterLeaveMessage(
@@ -45,11 +50,15 @@ public class ChatController {
         );
     }
 
-    @PostMapping("/chat")
+    @MessageMapping("/chat")
     public ResponseEntity<Void> sendMessage(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody ChatMessageDto messageDto
+            @RequestBody ChatMessageDto messageDto,
+            @Header("Authorization") String token
     ) {
+
+        Claims parser = jwtExtractor.parseClaim(token.replace("Bearer ", ""));
+        Long userId = parser.get("user_id", Long.class);
+
         chatMessageService.sendChatMessage(userId, messageDto);
         return ResponseEntity.ok(null);
     }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
채팅 전송 websocket으로 변경
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 채팅 전송 post -> websocket 방식으로
- ✨ ChatService 불러올 메시지 없는 경우 로직 수정
- ✨ JwtExtractor parseClaim public으로 변경

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2